### PR TITLE
fix(Stories): prevent overflow and add ability to scroll huge text in story card

### DIFF
--- a/src/components/Stories/components/StoriesLayout/StoriesLayout.scss
+++ b/src/components/Stories/components/StoriesLayout/StoriesLayout.scss
@@ -88,6 +88,7 @@ $textBlockMargin: 16px;
         justify-content: center;
         flex-direction: column;
         margin-bottom: $smallMargin;
+        overflow: hidden;
     }
 
     &__text-header {
@@ -98,6 +99,7 @@ $textBlockMargin: 16px;
     &__text-content {
         @include mixins.text-body-2();
         color: var(--g-color-text-complementary);
+        overflow-y: scroll;
 
         #{$block}__text-header + & {
             margin-top: $textBlockMargin;


### PR DESCRIPTION
In some cases when description text in story card is very big it will overflow out of the story card's borders.
This small fix add scroll for content if it too huge for the card.