### PR TITLE
fix(Notifications): fixed notification's actions changing height when they disappear

### DIFF
--- a/src/components/Notification/Notification.scss
+++ b/src/components/Notification/Notification.scss
@@ -12,7 +12,7 @@ $notificationSourceIconSize: 36px;
     box-sizing: border-box;
     width: 100%;
 
-    &:hover {
+    &_active:hover {
         background: var(--g-color-base-simple-hover);
     }
 

--- a/src/components/Notification/Notification.scss
+++ b/src/components/Notification/Notification.scss
@@ -84,6 +84,7 @@ $notificationSourceIconSize: 36px;
     }
 
     &__actions_right-side-actions {
+        height: 28px;
         opacity: 0;
     }
     &:hover &__actions_right-side-actions {

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -39,11 +39,9 @@ export const Notification = React.memo(function Notification(props: Props) {
                         </div>
                         {title ? <div className={b('right-title')}>{title}</div> : null}
                     </div>
-                    {props.notification.sideActions ? (
-                        <div className={b('actions', {'right-side-actions': true})}>
-                            {props.notification.sideActions}
-                        </div>
-                    ) : null}
+                    <div className={b('actions', {'right-side-actions': true})}>
+                        {props.notification.sideActions}
+                    </div>
                 </div>
                 <div className={b('right-content')}>{content}</div>
                 {props.notification.bottomActions ? (

--- a/src/components/Notifications/NotificationWrapper.tsx
+++ b/src/components/Notifications/NotificationWrapper.tsx
@@ -74,6 +74,7 @@ export const NotificationWrapper = (props: {
             className={b('notification-wrapper', {
                 archived: notification.archived,
                 unread: notification.unread,
+                active: Boolean(notification.onClick),
             })}
             ref={ref}
             style={style}

--- a/src/components/Notifications/Notifications.scss
+++ b/src/components/Notifications/Notifications.scss
@@ -11,6 +11,7 @@ $block: '.#{variables.$ns}notifications';
 
     &__head {
         display: flex;
+        align-items: center;
         padding: 16px;
         border-bottom: 1px solid var(--g-color-line-generic);
     }
@@ -60,6 +61,7 @@ $block: '.#{variables.$ns}notifications';
     &__actions {
         display: flex;
         align-items: center;
+        height: 28px;
     }
 
     &__notification-wrapper:not(:first-child)::before {

--- a/src/components/Notifications/Notifications.scss
+++ b/src/components/Notifications/Notifications.scss
@@ -72,8 +72,8 @@ $block: '.#{variables.$ns}notifications';
     }
 
     // :hover
-    &__notification-wrapper:hover:not(:first-child)::before,
-    &__notification-wrapper:hover + &__notification-wrapper::before,
+    &__notification-wrapper_active:hover:not(:first-child)::before,
+    &__notification-wrapper_active:hover + &__notification-wrapper::before,
     // .unread
     &__notification-wrapper_unread:not(:first-child)::before,
     &__notification-wrapper_unread + &__notification-wrapper::before {

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -45,7 +45,7 @@ export const Notifications = React.memo(function Notifications(props: Notificati
         <div className={b()}>
             <div className={b('head')}>
                 <div className={b('head-title')}>{props.title || i18n('title')}</div>
-                {props.actions ? <div className={b('actions')}>{props.actions}</div> : null}
+                {<div className={b('actions')}>{props.actions}</div>}
             </div>
             <div className={b('body')}>{content}</div>
         </div>


### PR DESCRIPTION
### The problem
If we show/hide notifications' actions, the height changes as well
(left — with actions, right — without actions)

<img width="768" alt="image" src="https://github.com/gravity-ui/components/assets/18216279/3b66decb-be38-4100-9049-86da972098d6">

### Solution

Set fixed height to actions' containers

I also fixed the `active` styles on hover