### PR TITLE
fix(AdaptiveTabs): prevent object convert to string

### DIFF
--- a/src/components/AdaptiveTabs/AdaptiveTabs.tsx
+++ b/src/components/AdaptiveTabs/AdaptiveTabs.tsx
@@ -72,7 +72,7 @@ class Tab extends React.Component<TabProps> {
 
     render() {
         const {active, disabled, hint, title = this.props.id} = this.props;
-        const stringTitle = (hint || typeof title === 'string' ? title : '') as string;   
+        const stringTitle = (hint || typeof title === 'string' ? title : '') as string;
         return (
             <div
                 className={b('tab', {active, disabled})}

--- a/src/components/AdaptiveTabs/AdaptiveTabs.tsx
+++ b/src/components/AdaptiveTabs/AdaptiveTabs.tsx
@@ -72,10 +72,11 @@ class Tab extends React.Component<TabProps> {
 
     render() {
         const {active, disabled, hint, title = this.props.id} = this.props;
+        const stringTitle = (hint || typeof title === 'string' ? title : '') as string;   
         return (
             <div
                 className={b('tab', {active, disabled})}
-                title={String(hint || title || '')}
+                title={stringTitle}
                 onClick={disabled ? undefined : this.onClick}
             >
                 {title}


### PR DESCRIPTION
when the title is not a string, the String(title) is [Object object]. Therefore, we shouldn't pass the title to "title" attribute if we can't convert it correctly

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.