### PR TITLE
fix(HelpPopover): set default button type

### DIFF
--- a/src/components/HelpPopover/HelpPopover.tsx
+++ b/src/components/HelpPopover/HelpPopover.tsx
@@ -21,6 +21,7 @@ export function HelpPopover(props: HelpPopoverProps) {
         <Popover {...props} className={b(null, props.className)}>
             <button
                 ref={props.buttonRef}
+                type="button"
                 {...props.buttonProps}
                 className={b('button', props.buttonProps?.className)}
             >


### PR DESCRIPTION
The problem is that default button type is "submit" and if `<HelpPopover>` is used inside `<form>`, click on it leads to unexpected submitting.