### PR TITLE
docs(Notifications): fix typo and add reference;

### DIFF
--- a/src/components/Notifications/README.md
+++ b/src/components/Notifications/README.md
@@ -43,19 +43,19 @@ For more code examples go to [Notifications.stories.tsx](https://github.com/grav
 
 **Notifications** — renders notifications and actions on these notifications.
 
-| Property                    | Type                  | Required | Default           | Description                                                                               |
-| :-------------------------- | :-------------------- | :------: | :---------------- | :---------------------------------------------------------------------------------------- |
-| `notifications`             | `NotificationProps[]` |  `true`  | `false`           | Touch device (mobile) mode                                                                |
-| `title`                     | `ReactNode`           |          | `"Notifications"` | Notifications' title                                                                      |
-| `actions`                   | `ReactNode`           |          |                   | Notifications' actions (e.g. create new, mark all as read)                                |
-| `areAllNotificationsLoaded` | `boolean`             |          | `false`           | When `true` renders a Loader instead of the notifications                                 |
-| `onLoadMoreNotifications`   | `() => Promise`       |          | `noop`            | Callback is called when the user scrolls to the end (so you can fetch more notifications) |
-| `isLoading`                 | `boolean`             |          | `false`           | When `true` renders a Loader instead of the notifications                                 |
-| `errorContent`              | `ReactNode`           |          |                   | Used for the Error state (the message under the «Error»)                                  |
-| `errorImage`                | `ReactNode`           |          |                   | Custom image for the Error state                                                          |
-| `emptyContent`              | `ReactNode`           |          |                   | Same as `errorContent`, but for the Empty state                                           |
-| `emptyImage`                | `ReactNode`           |          |                   | Custom image for the Empty state                                                          |
-| `swipeThreshold`            | `number`              |          | 0.4               | A value from 0 to 1 — the more the harder it is to swipe                                  |
+| Property                    | Type                  | Required | Default           | Description                                                                                                                                            |
+|:----------------------------|:----------------------|:--------:|:------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `notifications`             | `NotificationProps[]` |  `true`  |                   | List of Notifications to display. [Notification' types](https://github.com/gravity-ui/components/blob/main/src/components/Notification/definitions.ts) |
+| `title`                     | `ReactNode`           |          | `"Notifications"` | Notifications' title                                                                                                                                   |
+| `actions`                   | `ReactNode`           |          |                   | Notifications' actions (e.g. create new, mark all as read)                                                                                             |
+| `areAllNotificationsLoaded` | `boolean`             |          | `false`           | When `true` renders a Loader instead of the notifications                                                                                              |
+| `onLoadMoreNotifications`   | `() => Promise`       |          | `noop`            | Callback is called when the user scrolls to the end (so you can fetch more notifications)                                                              |
+| `isLoading`                 | `boolean`             |          | `false`           | When `true` renders a Loader instead of the notifications                                                                                              |
+| `errorContent`              | `ReactNode`           |          |                   | Used for the Error state (the message under the «Error»)                                                                                               |
+| `errorImage`                | `ReactNode`           |          |                   | Custom image for the Error state                                                                                                                       |
+| `emptyContent`              | `ReactNode`           |          |                   | Same as `errorContent`, but for the Empty state                                                                                                        |
+| `emptyImage`                | `ReactNode`           |          |                   | Custom image for the Empty state                                                                                                                       |
+| `swipeThreshold`            | `number`              |          | 0.4               | A value from 0 to 1 — the more the harder it is to swipe                                                                                               |
 
 **Notification** — renders a notification with actions (side/bottom/swipe).
 


### PR DESCRIPTION
While working with the Notifications component, I discovered a small typo in the documentation. The props was incorrectly described.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.