### PR TITLE
fix(AdaptiveTabs): fix border-case with incorrect firstHiddenTabIndex

### DIFF
--- a/src/components/AdaptiveTabs/AdaptiveTabs.tsx
+++ b/src/components/AdaptiveTabs/AdaptiveTabs.tsx
@@ -456,11 +456,19 @@ export class AdaptiveTabs<T> extends React.Component<AdaptiveTabsProps<T>, Adapt
             }
         }
 
-        if (maxHiddenTabWidth) {
+        if (maxHiddenTabWidth && typeof firstHiddenTabIndexForSequentialCase === 'number') {
             let rightSpace = maxHiddenTabWidth - emptySpace;
 
-            for (let j = firstHiddenTabIndexForSequentialCase! - 1; j >= 0; j--) {
-                rightSpace = rightSpace - this.tabsWidth[j];
+            // If firstHiddenTabIndexForSequentialCase exists, then we should
+            // start firstHiddenTabIndex from firstHiddenTabIndexForSequentialCase,
+            // reducing it until everything is correct
+            firstHiddenTabIndex = firstHiddenTabIndexForSequentialCase;
+
+            for (let j = firstHiddenTabIndexForSequentialCase - 1; j >= 0; j--) {
+                // We need to use maxHiddenTabWidth instead of tabWidth[i],
+                // beacause the tab, that we are going to render at index j
+                // may be active tab, which can be wider than real tab at index j
+                rightSpace = rightSpace - maxHiddenTabWidth;
 
                 if (rightSpace < 0) {
                     firstHiddenTabIndex = j + (tabChosenFromSelectIndex > j ? 0 : 1);


### PR DESCRIPTION
Fix border-case with incorrect firstHiddenTabIndex from small to next size.

**How to produce in actual deployed storybook:**
Just scale AdaptiveTabs from this:
<img width="1279" alt="image" src="https://github.com/gravity-ui/components/assets/15093838/94b4be1a-d54f-4c2c-9397-2fbc60582f1c">


To this:
<img width="255" alt="image" src="https://github.com/gravity-ui/components/assets/15093838/a9b4415c-2145-43b3-ab44-5ddb3f63bc9e">

And all the tabs from second will just disappear (in fact they will be hidden as overflown).

**What does this fix do:**

<img width="539" alt="image" src="https://github.com/gravity-ui/components/assets/15093838/f7c5fe5e-24c5-42eb-bef2-109e381179f7">

Here it is incorrect to use `tabsWidth[j]`, because the tab, that we are going to render at index `j` may be active tab, which can be wider than real tab at index `j`.

Also fixed eslint warnings in nearby code.