### PR TITLE
fix(AdaptiveTabs): fix behaviour when resizing with opened "More" menu

### DIFF
--- a/src/components/AdaptiveTabs/AdaptiveTabs.tsx
+++ b/src/components/AdaptiveTabs/AdaptiveTabs.tsx
@@ -869,7 +869,7 @@ export class AdaptiveTabs<T> extends React.Component<AdaptiveTabsProps<T>, Adapt
 
     renderSelect() {
         const activeTabID = this.activeTab;
-        const {firstHiddenTabIndex, tabChosenFromSelectId} = this.state;
+        const {firstHiddenTabIndex, tabChosenFromSelectId, isSelectOpened} = this.state;
         const {items, moreControlProps} = this.props;
 
         const itemsForSelect = items
@@ -886,6 +886,7 @@ export class AdaptiveTabs<T> extends React.Component<AdaptiveTabsProps<T>, Adapt
 
         return (
             <Select
+                open={isSelectOpened}
                 onUpdate={this.onChooseTabFromSelect}
                 options={itemsForSelect}
                 value={[]}


### PR DESCRIPTION
Fix for issue https://github.com/gravity-ui/components/issues/18

Probably was broken since when moved to new version of Select component