### PR TITLE
feat(Reactions): add `addButtonPlacement` property

### DIFF
--- a/src/components/Reactions/README.md
+++ b/src/components/Reactions/README.md
@@ -87,7 +87,6 @@ For more code examples go to [Reactions.stories.tsx](https://github.com/gravity-
 | :------------------- | :------------------------------------------ | :------: | :------ | :--------------------------------------------------------------------------------------------- |
 | `addButtonPlacement` | `'start' or 'end'`                          |          | `'end'` | Position of the "Add reaction" button.                                                         |
 | `className`          | `string`                                    |          |         | HTML `class` attribute                                                                         |
-| `hideAddButton`      | `boolean`                                   |          | `false` | Should we hide the "Add reaction" button.                                                      |
 | `onToggle`           | `(value: string) => void`                   |          |         | Fires when a user clicks on a Reaction (in a Palette or in the Reactions' list)                |
 | `paletteProps`       | `ReactionsPaletteProps`                     |  `true`  |         | Notifications' palette props — it's a `Palette` component with available reactions to the user |
 | `qa`                 | `string`                                    |          |         | `qa` attribute for testing                                                                     |

--- a/src/components/Reactions/README.md
+++ b/src/components/Reactions/README.md
@@ -7,8 +7,7 @@ Component for user reactions (e.g. 👍, 😊, 😎 etc) as new GitHub comments 
 ```typescript
 import React from 'react';
 
-import {PaletteOption} from '@gravity-ui/uikit';
-import {ReactionState, Reactions} from '@gravity-ui/components';
+import {Reactions, ReactionProps, ReactionState} from '@gravity-ui/components';
 
 const user = {
     spongeBob: {name: 'Sponge Bob'},
@@ -20,18 +19,18 @@ const currentUser = user.spongeBob;
 const option = {
     'thumbs-up': {content: '👍', value: 'thumbs-up'},
     cool: {content: '😎', value: 'cool'},
-} satisfies Record<string, PaletteOption>;
+} satisfies Record<string, ReactionProps>;
 
-const options = Object.values(option);
+const options: ReactionProps[] = Object.values(option);
 
-const YourComponent = () => {
+export const YourComponent = () => {
     // You can set up a mapping: reaction.value -> users reacted
     const [usersReacted, setUsersReacted] = React.useState({
         [option.cool.value]: [user.spongeBob],
     });
 
     // And then convert that mapping into an array of ReactionState
-    const reactions = React.useMemo(
+    const reactionsState = React.useMemo(
         () =>
             Object.entries(usersReacted).map(
                 ([value, users]): ReactionState => ({
@@ -44,7 +43,7 @@ const YourComponent = () => {
     );
 
     // You can then handle clicking on a reaction with changing the inital mapping,
-    // and the array of ReactionState will change accordingly
+    // and the reactionsState array will change accordingly
     const onToggle = React.useCallback(
         (value: string) => {
             if (!usersReacted[value]) {
@@ -74,9 +73,7 @@ const YourComponent = () => {
         [usersReacted],
     );
 
-    return (
-        <Reactions palette={{options}} reactions={reactions} onToggle={onToggle} />
-    );
+    return <Reactions reactions={options} reactionsState={reactionsState} onToggle={onToggle} />;
 };
 ```
 
@@ -86,18 +83,19 @@ For more code examples go to [Reactions.stories.tsx](https://github.com/gravity-
 
 **ReactionsProps** (main component props — Reactions' list):
 
-| Property         | Type                                        | Required | Default | Description                                                                                    |
-| :--------------- | :------------------------------------------ | :------: | :------ | :--------------------------------------------------------------------------------------------- |
-| `className`      | `string`                                    |          |         | HTML `class` attribute                                                                         |
-| `onToggle`       | `(value: string) => void`                   |          |         | Fires when a user clicks on a Reaction (in a Palette or in the Reactions' list)                |
-| `paletteProps`   | `ReactionsPaletteProps`                     |  `true`  |         | Notifications' palette props — it's a `Palette` component with available reactions to the user |
-| `qa`             | `string`                                    |          |         | `qa` attribute for testing                                                                     |
-| `reactions`      | `PaletteOption[]`                           |  `true`  |         | List of all available reactions                                                                |
-| `reactionsState` | `ReactionState[]`                           |  `true`  |         | List of reactions that were used                                                               |
-| `readOnly`       | `boolean`                                   |          | `false` | readOnly state (usage example: only signed in users can react)                                 |
-| `renderTooltip`  | `(state: ReactionState) => React.ReactNode` |          |         | Reaction's tooltip with the list of reacted users for example                                  |
-| `size`           | `ButtonSize`                                |          | `m`     | Buttons's size                                                                                 |
-| `style`          | `React.CSSProperties`                       |          |         | HTML `style` attribute                                                                         |
+| Property            | Type                                        | Required | Default   | Description                                                                                    |
+| :------------------ | :------------------------------------------ | :------: | :-------- | :--------------------------------------------------------------------------------------------- |
+| `addButtonPosition` | `'left' or 'right' or 'none'`               |          | `'right'` | Position of the "Add reaction" button. Use 'none' to hide the button.                          |
+| `className`         | `string`                                    |          |           | HTML `class` attribute                                                                         |
+| `onToggle`          | `(value: string) => void`                   |          |           | Fires when a user clicks on a Reaction (in a Palette or in the Reactions' list)                |
+| `paletteProps`      | `ReactionsPaletteProps`                     |  `true`  |           | Notifications' palette props — it's a `Palette` component with available reactions to the user |
+| `qa`                | `string`                                    |          |           | `qa` attribute for testing                                                                     |
+| `reactions`         | `PaletteOption[]`                           |  `true`  |           | List of all available reactions                                                                |
+| `reactionsState`    | `ReactionState[]`                           |  `true`  |           | List of reactions that were used                                                               |
+| `readOnly`          | `boolean`                                   |          | `false`   | readOnly state (usage example: only signed in users can react)                                 |
+| `renderTooltip`     | `(state: ReactionState) => React.ReactNode` |          |           | Reaction's tooltip with the list of reacted users for example                                  |
+| `size`              | `ButtonSize`                                |          | `m`       | Buttons's size                                                                                 |
+| `style`             | `React.CSSProperties`                       |          |           | HTML `style` attribute                                                                         |
 
 **ReactionState** (single reaction props):
 

--- a/src/components/Reactions/README.md
+++ b/src/components/Reactions/README.md
@@ -83,20 +83,20 @@ For more code examples go to [Reactions.stories.tsx](https://github.com/gravity-
 
 **ReactionsProps** (main component props — Reactions' list):
 
-| Property            | Type                                        | Required | Default | Description                                                                                    |
-| :------------------ | :------------------------------------------ | :------: | :------ | :--------------------------------------------------------------------------------------------- |
-| `addButtonPosition` | `'start' or 'end'`                          |          | `'end'` | Position of the "Add reaction" button.                                                         |
-| `className`         | `string`                                    |          |         | HTML `class` attribute                                                                         |
-| `hideAddButton`     | `boolean`                                   |          | `false` | Should we hide the "Add reaction" button.                                                      |
-| `onToggle`          | `(value: string) => void`                   |          |         | Fires when a user clicks on a Reaction (in a Palette or in the Reactions' list)                |
-| `paletteProps`      | `ReactionsPaletteProps`                     |  `true`  |         | Notifications' palette props — it's a `Palette` component with available reactions to the user |
-| `qa`                | `string`                                    |          |         | `qa` attribute for testing                                                                     |
-| `reactions`         | `PaletteOption[]`                           |  `true`  |         | List of all available reactions                                                                |
-| `reactionsState`    | `ReactionState[]`                           |  `true`  |         | List of reactions that were used                                                               |
-| `readOnly`          | `boolean`                                   |          | `false` | readOnly state (usage example: only signed in users can react)                                 |
-| `renderTooltip`     | `(state: ReactionState) => React.ReactNode` |          |         | Reaction's tooltip with the list of reacted users for example                                  |
-| `size`              | `ButtonSize`                                |          | `m`     | Buttons's size                                                                                 |
-| `style`             | `React.CSSProperties`                       |          |         | HTML `style` attribute                                                                         |
+| Property             | Type                                        | Required | Default | Description                                                                                    |
+| :------------------- | :------------------------------------------ | :------: | :------ | :--------------------------------------------------------------------------------------------- |
+| `addButtonPlacement` | `'start' or 'end'`                          |          | `'end'` | Position of the "Add reaction" button.                                                         |
+| `className`          | `string`                                    |          |         | HTML `class` attribute                                                                         |
+| `hideAddButton`      | `boolean`                                   |          | `false` | Should we hide the "Add reaction" button.                                                      |
+| `onToggle`           | `(value: string) => void`                   |          |         | Fires when a user clicks on a Reaction (in a Palette or in the Reactions' list)                |
+| `paletteProps`       | `ReactionsPaletteProps`                     |  `true`  |         | Notifications' palette props — it's a `Palette` component with available reactions to the user |
+| `qa`                 | `string`                                    |          |         | `qa` attribute for testing                                                                     |
+| `reactions`          | `PaletteOption[]`                           |  `true`  |         | List of all available reactions                                                                |
+| `reactionsState`     | `ReactionState[]`                           |  `true`  |         | List of reactions that were used                                                               |
+| `readOnly`           | `boolean`                                   |          | `false` | readOnly state (usage example: only signed in users can react)                                 |
+| `renderTooltip`      | `(state: ReactionState) => React.ReactNode` |          |         | Reaction's tooltip with the list of reacted users for example                                  |
+| `size`               | `ButtonSize`                                |          | `m`     | Buttons's size                                                                                 |
+| `style`              | `React.CSSProperties`                       |          |         | HTML `style` attribute                                                                         |
 
 **ReactionState** (single reaction props):
 

--- a/src/components/Reactions/README.md
+++ b/src/components/Reactions/README.md
@@ -1,6 +1,6 @@
 ## Reactions
 
-Component for user reactions (e.g. 👍, 😊, 😎 etc) as new GitHub comments for example.
+Component for user reactions (e.g. 👍, 😊, 😎 etc) as in GitHub comments for example.
 
 ### Usage example
 

--- a/src/components/Reactions/README.md
+++ b/src/components/Reactions/README.md
@@ -83,19 +83,20 @@ For more code examples go to [Reactions.stories.tsx](https://github.com/gravity-
 
 **ReactionsProps** (main component props — Reactions' list):
 
-| Property            | Type                                        | Required | Default   | Description                                                                                    |
-| :------------------ | :------------------------------------------ | :------: | :-------- | :--------------------------------------------------------------------------------------------- |
-| `addButtonPosition` | `'left' or 'right' or 'none'`               |          | `'right'` | Position of the "Add reaction" button. Use 'none' to hide the button.                          |
-| `className`         | `string`                                    |          |           | HTML `class` attribute                                                                         |
-| `onToggle`          | `(value: string) => void`                   |          |           | Fires when a user clicks on a Reaction (in a Palette or in the Reactions' list)                |
-| `paletteProps`      | `ReactionsPaletteProps`                     |  `true`  |           | Notifications' palette props — it's a `Palette` component with available reactions to the user |
-| `qa`                | `string`                                    |          |           | `qa` attribute for testing                                                                     |
-| `reactions`         | `PaletteOption[]`                           |  `true`  |           | List of all available reactions                                                                |
-| `reactionsState`    | `ReactionState[]`                           |  `true`  |           | List of reactions that were used                                                               |
-| `readOnly`          | `boolean`                                   |          | `false`   | readOnly state (usage example: only signed in users can react)                                 |
-| `renderTooltip`     | `(state: ReactionState) => React.ReactNode` |          |           | Reaction's tooltip with the list of reacted users for example                                  |
-| `size`              | `ButtonSize`                                |          | `m`       | Buttons's size                                                                                 |
-| `style`             | `React.CSSProperties`                       |          |           | HTML `style` attribute                                                                         |
+| Property            | Type                                        | Required | Default | Description                                                                                    |
+| :------------------ | :------------------------------------------ | :------: | :------ | :--------------------------------------------------------------------------------------------- |
+| `addButtonPosition` | `'start' or 'end'`                          |          | `'end'` | Position of the "Add reaction" button.                                                         |
+| `className`         | `string`                                    |          |         | HTML `class` attribute                                                                         |
+| `hideAddButton`     | `boolean`                                   |          | `false` | Should we hide the "Add reaction" button.                                                      |
+| `onToggle`          | `(value: string) => void`                   |          |         | Fires when a user clicks on a Reaction (in a Palette or in the Reactions' list)                |
+| `paletteProps`      | `ReactionsPaletteProps`                     |  `true`  |         | Notifications' palette props — it's a `Palette` component with available reactions to the user |
+| `qa`                | `string`                                    |          |         | `qa` attribute for testing                                                                     |
+| `reactions`         | `PaletteOption[]`                           |  `true`  |         | List of all available reactions                                                                |
+| `reactionsState`    | `ReactionState[]`                           |  `true`  |         | List of reactions that were used                                                               |
+| `readOnly`          | `boolean`                                   |          | `false` | readOnly state (usage example: only signed in users can react)                                 |
+| `renderTooltip`     | `(state: ReactionState) => React.ReactNode` |          |         | Reaction's tooltip with the list of reacted users for example                                  |
+| `size`              | `ButtonSize`                                |          | `m`     | Buttons's size                                                                                 |
+| `style`             | `React.CSSProperties`                       |          |         | HTML `style` attribute                                                                         |
 
 **ReactionState** (single reaction props):
 

--- a/src/components/Reactions/Reactions.tsx
+++ b/src/components/Reactions/Reactions.tsx
@@ -47,6 +47,13 @@ export interface ReactionsProps extends Pick<PaletteProps, 'size'>, QAProps, DOM
      */
     readOnly?: boolean;
     /**
+     * Position of the "Add reaction" button.
+     * Use 'none' to hide the button.
+     *
+     * @default 'right'
+     */
+    addButtonPosition?: 'left' | 'right' | 'none';
+    /**
      * If present, when a user hovers over the reaction, a popover appears with renderTooltip(state) content.
      * Can be used to display users who used this reaction.
      */
@@ -74,6 +81,7 @@ export function Reactions({
     paletteProps,
     readOnly,
     qa,
+    addButtonPosition = 'right',
     renderTooltip,
     onToggle,
 }: ReactionsProps) {
@@ -122,6 +130,28 @@ export function Reactions({
         [paletteProps, reactions, paletteValue, size, onUpdatePalette],
     );
 
+    const addReactionButton = readOnly ? null : (
+        <Popover
+            content={paletteContent}
+            tooltipContentClassName={b('add-reaction-popover')}
+            openOnHover={false}
+            hasArrow={false}
+            focusTrap
+            autoFocus
+        >
+            <Button
+                className={b('reaction-button')}
+                size={size}
+                extraProps={{'aria-label': i18n('add-reaction')}}
+                view="flat-secondary"
+            >
+                <Button.Icon>
+                    <Icon data={FaceSmile} size={buttonSizeToIconSize[size]} />
+                </Button.Icon>
+            </Button>
+        </Popover>
+    );
+
     return (
         <ReactionsContextProvider
             value={{
@@ -130,6 +160,8 @@ export function Reactions({
             }}
         >
             <Flex className={b(null, className)} style={style} gap={1} wrap={true} qa={qa}>
+                {addButtonPosition === 'left' ? addReactionButton : null}
+
                 {/* Reactions' list */}
                 {reactionsState.map((reaction) => {
                     const content = paletteOptionsMap[reaction.value]?.content ?? '?';
@@ -146,28 +178,7 @@ export function Reactions({
                     );
                 })}
 
-                {/* Add reaction button */}
-                {readOnly ? null : (
-                    <Popover
-                        content={paletteContent}
-                        tooltipContentClassName={b('add-reaction-popover')}
-                        openOnHover={false}
-                        hasArrow={false}
-                        focusTrap
-                        autoFocus
-                    >
-                        <Button
-                            className={b('reaction-button')}
-                            size={size}
-                            extraProps={{'aria-label': i18n('add-reaction')}}
-                            view="flat-secondary"
-                        >
-                            <Button.Icon>
-                                <Icon data={FaceSmile} size={buttonSizeToIconSize[size]} />
-                            </Button.Icon>
-                        </Button>
-                    </Popover>
-                )}
+                {addButtonPosition === 'right' ? addReactionButton : null}
             </Flex>
         </ReactionsContextProvider>
     );

--- a/src/components/Reactions/Reactions.tsx
+++ b/src/components/Reactions/Reactions.tsx
@@ -51,7 +51,7 @@ export interface ReactionsProps extends Pick<PaletteProps, 'size'>, QAProps, DOM
      *
      * @default 'end'
      */
-    addButtonPosition?: 'start' | 'end';
+    addButtonPlacement?: 'start' | 'end';
     /**
      * Should we hide the "Add reaction" button.
      *
@@ -86,7 +86,7 @@ export function Reactions({
     paletteProps,
     readOnly,
     qa,
-    addButtonPosition = 'end',
+    addButtonPlacement = 'end',
     hideAddButton = false,
     renderTooltip,
     onToggle,
@@ -166,7 +166,7 @@ export function Reactions({
             }}
         >
             <Flex className={b(null, className)} style={style} gap={1} wrap={true} qa={qa}>
-                {!hideAddButton && addButtonPosition === 'start' ? addReactionButton : null}
+                {!hideAddButton && addButtonPlacement === 'start' ? addReactionButton : null}
 
                 {/* Reactions' list */}
                 {reactionsState.map((reaction) => {
@@ -184,7 +184,7 @@ export function Reactions({
                     );
                 })}
 
-                {!hideAddButton && addButtonPosition === 'end' ? addReactionButton : null}
+                {!hideAddButton && addButtonPlacement === 'end' ? addReactionButton : null}
             </Flex>
         </ReactionsContextProvider>
     );

--- a/src/components/Reactions/Reactions.tsx
+++ b/src/components/Reactions/Reactions.tsx
@@ -53,12 +53,6 @@ export interface ReactionsProps extends Pick<PaletteProps, 'size'>, QAProps, DOM
      */
     addButtonPlacement?: 'start' | 'end';
     /**
-     * Should we hide the "Add reaction" button.
-     *
-     * @default false
-     */
-    hideAddButton?: boolean;
-    /**
      * If present, when a user hovers over the reaction, a popover appears with renderTooltip(state) content.
      * Can be used to display users who used this reaction.
      */
@@ -87,7 +81,6 @@ export function Reactions({
     readOnly,
     qa,
     addButtonPlacement = 'end',
-    hideAddButton = false,
     renderTooltip,
     onToggle,
 }: ReactionsProps) {
@@ -166,7 +159,7 @@ export function Reactions({
             }}
         >
             <Flex className={b(null, className)} style={style} gap={1} wrap={true} qa={qa}>
-                {!hideAddButton && addButtonPlacement === 'start' ? addReactionButton : null}
+                {addButtonPlacement === 'start' ? addReactionButton : null}
 
                 {/* Reactions' list */}
                 {reactionsState.map((reaction) => {
@@ -184,7 +177,7 @@ export function Reactions({
                     );
                 })}
 
-                {!hideAddButton && addButtonPlacement === 'end' ? addReactionButton : null}
+                {addButtonPlacement === 'end' ? addReactionButton : null}
             </Flex>
         </ReactionsContextProvider>
     );

--- a/src/components/Reactions/Reactions.tsx
+++ b/src/components/Reactions/Reactions.tsx
@@ -48,11 +48,16 @@ export interface ReactionsProps extends Pick<PaletteProps, 'size'>, QAProps, DOM
     readOnly?: boolean;
     /**
      * Position of the "Add reaction" button.
-     * Use 'none' to hide the button.
      *
-     * @default 'right'
+     * @default 'end'
      */
-    addButtonPosition?: 'left' | 'right' | 'none';
+    addButtonPosition?: 'start' | 'end';
+    /**
+     * Should we hide the "Add reaction" button.
+     *
+     * @default false
+     */
+    hideAddButton?: boolean;
     /**
      * If present, when a user hovers over the reaction, a popover appears with renderTooltip(state) content.
      * Can be used to display users who used this reaction.
@@ -81,7 +86,8 @@ export function Reactions({
     paletteProps,
     readOnly,
     qa,
-    addButtonPosition = 'right',
+    addButtonPosition = 'end',
+    hideAddButton = false,
     renderTooltip,
     onToggle,
 }: ReactionsProps) {
@@ -160,7 +166,7 @@ export function Reactions({
             }}
         >
             <Flex className={b(null, className)} style={style} gap={1} wrap={true} qa={qa}>
-                {addButtonPosition === 'left' ? addReactionButton : null}
+                {!hideAddButton && addButtonPosition === 'start' ? addReactionButton : null}
 
                 {/* Reactions' list */}
                 {reactionsState.map((reaction) => {
@@ -178,7 +184,7 @@ export function Reactions({
                     );
                 })}
 
-                {addButtonPosition === 'right' ? addReactionButton : null}
+                {!hideAddButton && addButtonPosition === 'end' ? addReactionButton : null}
             </Flex>
         </ReactionsContextProvider>
     );

--- a/src/components/Reactions/__stories__/Reactions.stories.tsx
+++ b/src/components/Reactions/__stories__/Reactions.stories.tsx
@@ -64,3 +64,22 @@ export const Size: StoryFn = () => {
         </Flex>
     );
 };
+
+export const AddButtonPosition: StoryFn = () => {
+    return (
+        <Flex direction="column" gap={4}>
+            <Flex direction="column" gap={2}>
+                <Text variant="subheader-1">Left</Text>
+                <Reactions {...useMockReactions()} addButtonPosition="left" />
+            </Flex>
+            <Flex direction="column" gap={2}>
+                <Text variant="subheader-1">Right</Text>
+                <Reactions {...useMockReactions()} addButtonPosition="right" />
+            </Flex>
+            <Flex direction="column" gap={2}>
+                <Text variant="subheader-1">None</Text>
+                <Reactions {...useMockReactions()} addButtonPosition="none" />
+            </Flex>
+        </Flex>
+    );
+};

--- a/src/components/Reactions/__stories__/Reactions.stories.tsx
+++ b/src/components/Reactions/__stories__/Reactions.stories.tsx
@@ -65,16 +65,16 @@ export const Size: StoryFn = () => {
     );
 };
 
-export const AddButtonPosition: StoryFn = () => {
+export const AddButtonPlacement: StoryFn = () => {
     return (
         <Flex direction="column" gap={4}>
             <Flex direction="column" gap={2}>
                 <Text variant="subheader-1">Start</Text>
-                <Reactions {...useMockReactions()} addButtonPosition="start" />
+                <Reactions {...useMockReactions()} addButtonPlacement="start" />
             </Flex>
             <Flex direction="column" gap={2}>
                 <Text variant="subheader-1">End</Text>
-                <Reactions {...useMockReactions()} addButtonPosition="end" />
+                <Reactions {...useMockReactions()} addButtonPlacement="end" />
             </Flex>
             <Flex direction="column" gap={2}>
                 <Text variant="subheader-1">Hide</Text>

--- a/src/components/Reactions/__stories__/Reactions.stories.tsx
+++ b/src/components/Reactions/__stories__/Reactions.stories.tsx
@@ -69,16 +69,16 @@ export const AddButtonPosition: StoryFn = () => {
     return (
         <Flex direction="column" gap={4}>
             <Flex direction="column" gap={2}>
-                <Text variant="subheader-1">Left</Text>
-                <Reactions {...useMockReactions()} addButtonPosition="left" />
+                <Text variant="subheader-1">Start</Text>
+                <Reactions {...useMockReactions()} addButtonPosition="start" />
             </Flex>
             <Flex direction="column" gap={2}>
-                <Text variant="subheader-1">Right</Text>
-                <Reactions {...useMockReactions()} addButtonPosition="right" />
+                <Text variant="subheader-1">End</Text>
+                <Reactions {...useMockReactions()} addButtonPosition="end" />
             </Flex>
             <Flex direction="column" gap={2}>
-                <Text variant="subheader-1">None</Text>
-                <Reactions {...useMockReactions()} addButtonPosition="none" />
+                <Text variant="subheader-1">Hide</Text>
+                <Reactions {...useMockReactions()} hideAddButton={true} />
             </Flex>
         </Flex>
     );

--- a/src/components/Reactions/__stories__/Reactions.stories.tsx
+++ b/src/components/Reactions/__stories__/Reactions.stories.tsx
@@ -76,10 +76,6 @@ export const AddButtonPlacement: StoryFn = () => {
                 <Text variant="subheader-1">End</Text>
                 <Reactions {...useMockReactions()} addButtonPlacement="end" />
             </Flex>
-            <Flex direction="column" gap={2}>
-                <Text variant="subheader-1">Hide</Text>
-                <Reactions {...useMockReactions()} hideAddButton={true} />
-            </Flex>
         </Flex>
     );
 };


### PR DESCRIPTION
Added a property (addButtonPosition) for placing the "Add reaction" button:

<img width="405" alt="изображение" src="https://github.com/user-attachments/assets/df41b759-9cca-4692-83d1-0352da15d9f7">

The default (`right`) stays the same