### PR TITLE
fix: update universal-cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@gravity-ui/icons": "^2.8.1",
         "lodash": "^4.17.21",
         "resize-observer-polyfill": "^1.5.1",
-        "universal-cookie": "^6.1.3"
+        "universal-cookie": "^7.2.1"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.23.9",
@@ -10206,6 +10206,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -27365,12 +27366,20 @@
       }
     },
     "node_modules/universal-cookie": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-6.1.3.tgz",
-      "integrity": "sha512-AETYRrhpRgl9T1YtnODmQE32G81U3A+f3HO3ZeK7efbXqe3x+RNOW4RTpV0iff7zJWhGYJA6EI0Mm+w50aFTAw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.2.1.tgz",
+      "integrity": "sha512-GEKneQ0sz8qbobkYM5s9elAx6l7GQDNVl3Siqmc7bt/YccyyXWDPn+fht3J1qMcaLwPrzkty3i+dNfPGP2/9hA==",
       "dependencies": {
         "@types/cookie": "^0.6.0",
-        "cookie": "^0.6.0"
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/universal-cookie/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@gravity-ui/icons": "^2.8.1",
         "lodash": "^4.17.21",
         "resize-observer-polyfill": "^1.5.1",
-        "universal-cookie": "^7.2.1"
+        "universal-cookie": "^7.2.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.23.9",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@gravity-ui/icons": "^2.8.1",
     "lodash": "^4.17.21",
     "resize-observer-polyfill": "^1.5.1",
-    "universal-cookie": "^7.2.1"
+    "universal-cookie": "^7.2.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.23.9",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@gravity-ui/icons": "^2.8.1",
     "lodash": "^4.17.21",
     "resize-observer-polyfill": "^1.5.1",
-    "universal-cookie": "^6.1.3"
+    "universal-cookie": "^7.2.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.23.9",


### PR DESCRIPTION
**Reason**
We need update `cookie` library
https://github.com/jshttp/cookie/pull/167

**About major update for the `unversal-cookie`**
https://github.com/bendotcodes/cookies/tree/v7.0.0
No breaking change has been made in v7. However, the entire build system has been rewritten and the output file structure has changed. The upgrade should be seamless unless if you were importing files in a subfolder. This is no longer supported.