### PR TITLE
feat(CookieConsent): add `modalClassName` property to `ConsentPopup` Modal

### DIFF
--- a/src/components/CookieConsent/CookieConsent.tsx
+++ b/src/components/CookieConsent/CookieConsent.tsx
@@ -49,6 +49,7 @@ export const CookieConsent = ({
                     <ConsentPopup
                         {...popupProps}
                         className={b()}
+                        rootClassName={b('root')}
                         step={manageCookies ? ConsentPopupStep.Manage : ConsentPopupStep.Main}
                         onAction={onConsentPopupAction}
                         onClose={onClose}

--- a/src/components/CookieConsent/CookieConsent.tsx
+++ b/src/components/CookieConsent/CookieConsent.tsx
@@ -49,7 +49,6 @@ export const CookieConsent = ({
                     <ConsentPopup
                         {...popupProps}
                         className={b()}
-                        rootClassName={b('root')}
                         step={manageCookies ? ConsentPopupStep.Manage : ConsentPopupStep.Main}
                         onAction={onConsentPopupAction}
                         onClose={onClose}

--- a/src/components/CookieConsent/README.md
+++ b/src/components/CookieConsent/README.md
@@ -53,6 +53,7 @@ const Analytics = () => {
       consentManager={consentManager}
       cookieList={cookieList}
       onConsentPopupClose={props.onClose}
+      modalClassName={'unique-class-name-for-adblockers'}
     />
   );
 };

--- a/src/components/CookieConsent/__stories__/CookieConsent.stories.tsx
+++ b/src/components/CookieConsent/__stories__/CookieConsent.stories.tsx
@@ -72,6 +72,7 @@ ConsentPopup.args = {
     consentMode: ConsentMode.Manage,
     policyLink: 'https://google.com',
     cookieList,
+    modalClassName: 'unique-class-name-for-adblockers',
 } as DefaultTemplateProps;
 
 export const ManageCookies = DefaultTemplate.bind({});
@@ -80,6 +81,7 @@ ManageCookies.args = {
     manageCookies: true,
     policyLink: 'https://google.com',
     cookieList,
+    modalClassName: 'unique-class-name-for-adblockers',
 } as DefaultTemplateProps;
 
 export const ConsentNotification = DefaultTemplate.bind({});

--- a/src/components/CookieConsent/components/ConsentPopup/ConsentPopup.tsx
+++ b/src/components/CookieConsent/components/ConsentPopup/ConsentPopup.tsx
@@ -101,7 +101,7 @@ export const ConsentPopup = ({
     policyLink,
     onAction,
     className,
-    rootClassName,
+    modalClassName,
     policyLinkText = i18n('label_policy_extended'),
     text,
     manageLabelText = i18n('manage_label_text_extended'),
@@ -157,7 +157,7 @@ export const ConsentPopup = ({
             open
             disableOutsideClick
             disableEscapeKeyDown
-            className={rootClassName}
+            className={modalClassName}
             contentClassName={b('modal-content', {step: currentStep, mobile})}
             onClose={onClose}
         >

--- a/src/components/CookieConsent/components/ConsentPopup/ConsentPopup.tsx
+++ b/src/components/CookieConsent/components/ConsentPopup/ConsentPopup.tsx
@@ -101,6 +101,7 @@ export const ConsentPopup = ({
     policyLink,
     onAction,
     className,
+    rootClassName,
     policyLinkText = i18n('label_policy_extended'),
     text,
     manageLabelText = i18n('manage_label_text_extended'),
@@ -156,6 +157,7 @@ export const ConsentPopup = ({
             open
             disableOutsideClick
             disableEscapeKeyDown
+            className={rootClassName}
             contentClassName={b('modal-content', {step: currentStep, mobile})}
             onClose={onClose}
         >

--- a/src/components/CookieConsent/components/ConsentPopup/types.ts
+++ b/src/components/CookieConsent/components/ConsentPopup/types.ts
@@ -40,6 +40,7 @@ export type ConsentPopupProps = ConsentPopupData &
     CookieConsentBaseProps & {
         /* Active step */
         step?: `${ConsentPopupStep}`;
+        rootClassName?: string;
     };
 
 export interface HeaderProps {

--- a/src/components/CookieConsent/components/ConsentPopup/types.ts
+++ b/src/components/CookieConsent/components/ConsentPopup/types.ts
@@ -40,7 +40,8 @@ export type ConsentPopupProps = ConsentPopupData &
     CookieConsentBaseProps & {
         /* Active step */
         step?: `${ConsentPopupStep}`;
-        rootClassName?: string;
+        /* Class for the root Modal node */
+        modalClassName?: string;
     };
 
 export interface HeaderProps {


### PR DESCRIPTION
Added the `rootClassName` property to the `ConsentPopup` component that can be used in white-lists for adblockers.

I hereby agree to the terms of the CLA available at: [link](https://yandex.ru/legal/cla/?lang=en).