### PR TITLE
fix(Reactions): Increased Reactions buttons' border-radius to 16px

### DIFF
--- a/src/components/Reactions/Reactions.scss
+++ b/src/components/Reactions/Reactions.scss
@@ -12,6 +12,10 @@ $block: '.#{variables.$ns}reactions';
         padding: 16px;
     }
 
+    &__reaction-button {
+        --g-button-border-radius: 16px;
+    }
+
     &__reaction-button-content_size_xs {
         font-size: 12px;
     }


### PR DESCRIPTION
### Before

![image](https://github.com/user-attachments/assets/1ecbf393-aa4d-40db-9d8d-45bcdd6feb88)

### After

![image](https://github.com/user-attachments/assets/fa8a22cc-4851-4b16-955c-30bff9468690)
