### PR TITLE
ci: update workflows actions for v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   verify_files:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm
@@ -32,11 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm

--- a/.github/workflows/main-preview.yml
+++ b/.github/workflows/main-preview.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Install Packages

--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -8,6 +8,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: gravity-ui/preview-build-action@v1
+      - uses: gravity-ui/preview-build-action@v2
         with:
           node-version: 18

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: gravity-ui/preview-deploy-action@v1
+      - uses: gravity-ui/preview-deploy-action@v2
         with:
           project: components
           github-token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -23,8 +23,8 @@ jobs:
               exit 1
             fi
           fi
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,19 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - release/v*
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: gravity-ui/release-action@v1
+      - name: Release from ${{ github.ref_name }}
+        uses: gravity-ui/release-action@v1
         with:
           github-token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
           npm-token: ${{ secrets.GRAVITY_UI_BOT_NPM_TOKEN }}
           node-version: 18
+          default-branch: ${{ github.ref_name != 'main' && github.ref_name || null }}
+          npm-dist-tag: ${{ github.ref_name != 'main' && 'untagged' || 'latest' }}


### PR DESCRIPTION
Build is broken in v3-branch since it uses previous workflow versions and ci is not running on branches that is not destinated to main

Example: https://github.com/gravity-ui/components/pull/265
