### PR TITLE
feat(Notifications): Allowed ReactNode in source icon + moved the "source • date" to the bottom

### DIFF
--- a/src/components/Notification/Notification.scss
+++ b/src/components/Notification/Notification.scss
@@ -17,48 +17,39 @@ $notificationSourceIconSize: 36px;
     }
 
     &__right {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
         flex: 1;
-        overflow-x: hidden;
     }
 
-    &__right-top-part {
+    &__title-and-actions {
         display: flex;
         align-items: center;
         width: 100%;
         overflow-x: hidden;
     }
 
-    &__right-meta-and-title {
+    &__title-wrapper {
         flex: 1;
         min-width: 0;
         overflow-x: hidden;
     }
 
-    &__right-meta,
-    &__right-title {
+    &__source-text,
+    &__title {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
     }
 
-    &__right-meta {
-        display: flex;
-        gap: 4px;
+    &__source-text {
         color: var(--g-color-text-secondary);
     }
 
-    &__right-title {
+    &__title {
         font-weight: 500;
-        font-size: 13px;
-        line-height: 18px;
-
         color: var(--g-color-text-primary);
     }
 
-    &__right-content {
+    &__content {
         font-size: 13px;
         line-height: 18px;
 
@@ -75,23 +66,23 @@ $notificationSourceIconSize: 36px;
     &__actions {
         display: flex;
         align-items: center;
+    }
+
+    &__actions_bottom-actions {
+        margin-block-start: 8px;
+        gap: 8px;
         flex-wrap: wrap;
     }
 
-    &__actions_right-bottom-actions {
-        margin-block-start: 8px;
-        gap: 8px;
-    }
-
-    &__actions_right-side-actions {
+    &__actions_side-actions {
         height: 28px;
         opacity: 0;
     }
-    &:hover &__actions_right-side-actions,
-    &__actions_right-side-actions:focus-within {
+    &:hover &__actions_side-actions,
+    &__actions_side-actions:focus-within {
         opacity: 1;
     }
-    &_mobile &__actions_right-side-actions {
+    &_mobile &__actions_side-actions {
         opacity: 1;
     }
 

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {Icon, Link, useMobile, useUniqId} from '@gravity-ui/uikit';
+import {Flex, Icon, Link, useMobile, useUniqId} from '@gravity-ui/uikit';
 
 import {CnMods, block} from '../utils/cn';
 
@@ -22,6 +22,36 @@ export const Notification = React.memo(function Notification(props: Props) {
 
     const sourceIcon = source && renderSourceIcon(source, titleId);
 
+    const renderedTitle = title ? (
+        <div className={b('title-wrapper')}>{<div className={b('title')}>{title}</div>}</div>
+    ) : null;
+
+    const renderedSideActions = (
+        <div className={b('actions', {'side-actions': true})}>{props.notification.sideActions}</div>
+    );
+
+    const renderedBottomActions = props.notification.bottomActions ? (
+        <div className={b('actions', {'bottom-actions': true})}>
+            {props.notification.bottomActions}
+        </div>
+    ) : null;
+
+    const renderedContent = <div className={b('content')}>{content}</div>;
+
+    const renderedSourceText = (
+        <Flex className={b('source-text')} gap={1}>
+            {source?.title
+                ? renderSourceTitle({
+                      title: source.title,
+                      href: source.href,
+                      id: titleId,
+                  })
+                : null}
+            {source?.title && formattedDate ? <span>•</span> : null}
+            {formattedDate ? <div className={b('right-date')}>{formattedDate}</div> : null}
+        </Flex>
+    );
+
     return (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
         <div
@@ -31,35 +61,26 @@ export const Notification = React.memo(function Notification(props: Props) {
             onClick={notification.onClick}
         >
             {sourceIcon ? <div className={b('left')}>{sourceIcon}</div> : null}
-            <div className={b('right')}>
-                <div className={b('right-top-part')}>
-                    <div className={b('right-meta-and-title')}>
-                        <div className={b('right-meta')}>
-                            {source?.title
-                                ? renderSourceTitle({
-                                      title: source.title,
-                                      href: source.href,
-                                      id: titleId,
-                                  })
-                                : null}
-                            {source?.title && formattedDate ? <span>•</span> : null}
-                            {formattedDate ? (
-                                <div className={b('right-date')}>{formattedDate}</div>
-                            ) : null}
+
+            <Flex className={b('right')} justifyContent="space-between" gap={2} overflow="hidden">
+                <Flex direction="column" overflow="hidden">
+                    {renderedTitle ? (
+                        <div className={b('title-and-actions')}>
+                            {renderedTitle}
+                            {renderedSideActions}
                         </div>
-                        {title ? <div className={b('right-title')}>{title}</div> : null}
-                    </div>
-                    <div className={b('actions', {'right-side-actions': true})}>
-                        {props.notification.sideActions}
-                    </div>
-                </div>
-                <div className={b('right-content')}>{content}</div>
-                {props.notification.bottomActions ? (
-                    <div className={b('actions', {'right-bottom-actions': true})}>
-                        {props.notification.bottomActions}
-                    </div>
-                ) : null}
-            </div>
+                    ) : null}
+
+                    <Flex direction="column">
+                        {renderedContent}
+                        {renderedSourceText}
+                    </Flex>
+
+                    {renderedBottomActions}
+                </Flex>
+
+                {renderedTitle ? null : renderedSideActions}
+            </Flex>
         </div>
     );
 });
@@ -69,7 +90,7 @@ interface RenderSourceTitleOptions {
     href?: string;
     id: string;
 }
-function renderSourceTitle({title, href, id}: RenderSourceTitleOptions): JSX.Element {
+function renderSourceTitle({title, href, id}: RenderSourceTitleOptions): React.ReactNode {
     return href ? (
         <Link className={b('right-source-title')} href={href} target="_blank" title={title} id={id}>
             {title}
@@ -81,7 +102,7 @@ function renderSourceTitle({title, href, id}: RenderSourceTitleOptions): JSX.Ele
     );
 }
 
-function renderSourceIcon(source: NotificationSourceProps, titleId: string): JSX.Element | null {
+function renderSourceIcon(source: NotificationSourceProps, titleId: string): React.ReactNode {
     const iconElement = getIconElement(source);
 
     if (!iconElement) return null;
@@ -95,11 +116,13 @@ function renderSourceIcon(source: NotificationSourceProps, titleId: string): JSX
     );
 }
 
-function getIconElement(source: NotificationSourceProps): JSX.Element | null {
+function getIconElement(source: NotificationSourceProps): React.ReactNode {
     if ('icon' in source && source.icon) {
         return <Icon className={b('source-icon')} size={36} data={source.icon} />;
     } else if ('imageSrc' in source && source.imageSrc) {
         return <img alt="" className={b('source-icon')} src={source.imageSrc} />;
+    } else if ('custom' in source && source.custom) {
+        return source.custom;
     } else {
         return null;
     }

--- a/src/components/Notification/definitions.ts
+++ b/src/components/Notification/definitions.ts
@@ -4,12 +4,12 @@ import {ButtonProps, IconData, QAProps} from '@gravity-ui/uikit';
 
 export type NotificationTheme = 'success' | 'info' | 'warning' | 'danger';
 
-type SvgOrImage = {icon: IconData} | {imageSrc: string};
+type NotificationIcon = {icon: IconData} | {imageSrc: string} | {custom: React.ReactNode};
 
 export type NotificationSourceProps = {
     title?: string;
     href?: string;
-} & Partial<SvgOrImage>;
+} & Partial<NotificationIcon>;
 
 export type NotificationSwipeActionProps = {
     content: React.ReactNode;

--- a/src/components/Notifications/__stories__/mockData.tsx
+++ b/src/components/Notifications/__stories__/mockData.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import {Archive, ArrowRotateLeft, CircleCheck, Funnel, TrashBin} from '@gravity-ui/icons';
-import {DropdownMenu, Link} from '@gravity-ui/uikit';
+import {Avatar, DropdownMenu, Icon, Link} from '@gravity-ui/uikit';
 
 import {NotificationAction} from '../../Notification/NotificationAction';
 import {NotificationSwipeAction} from '../../Notification/NotificationSwipeAction';
@@ -99,25 +99,19 @@ export const mockNotifications: NotificationProps[] = [
                 <Link target={'_blank'} href={LINK}>
                     ticket
                 </Link>
-                <img
-                    alt=""
-                    style={{
-                        position: 'absolute',
-                        insetBlockEnd: 0,
-                        insetInlineEnd: 0,
-                        borderRadius: '100%',
-                        background: 'rgba(0, 0, 0, 0.1)',
-                    }}
-                    width={18}
-                    height={18}
-                    src={trackerUserIcon}
-                ></img>
             </div>
         ),
         formattedDate: 'just now',
         source: {
             title: 'Tracker',
-            icon: svgTrackerStoryIcon,
+            custom: (
+                <div style={{position: 'relative'}}>
+                    <Avatar imgUrl={trackerUserIcon} />
+                    <div style={{position: 'absolute', right: '0', bottom: '0'}}>
+                        <Icon size={14} data={svgTrackerStoryIcon} />
+                    </div>
+                </div>
+            ),
             href: LINK,
         },
         swipeActions: notificationsMockSwipeActions,


### PR DESCRIPTION
### Before

![image](https://github.com/user-attachments/assets/b2e06451-30ea-4daa-a0d6-c860021c2d96)

### After

![image](https://github.com/user-attachments/assets/f198c70a-435c-4e28-a380-9cf62112ec2f)

### What changed in the code

- I did some refactoring of the `Notification` component
- renamed some classNames,
- added `custom: React.ReactNode` property to `NotificationIcon`