### PR TITLE
Fix(Gallery): align-items 'flex-start' value

### DIFF
--- a/src/components/Gallery/Gallery.scss
+++ b/src/components/Gallery/Gallery.scss
@@ -18,7 +18,7 @@ $verticalGalleryMargin: 28px;
 
     &__header {
         display: flex;
-        align-items: start;
+        align-items: flex-start;
 
         padding: var(--g-spacing-2) var(--g-spacing-3) var(--g-spacing-2) var(--g-spacing-5);
 


### PR DESCRIPTION
Fix due to eslint warning 'autoprefixer: start value has mixed support, consider using flex-start instead'