### PR TITLE
feat(ItemSelector): various imrovements

### DIFF
--- a/src/components/ItemSelector/ItemSelector.tsx
+++ b/src/components/ItemSelector/ItemSelector.tsx
@@ -45,36 +45,48 @@ export class ItemSelector<T> extends React.Component<ItemSelectorProps<T>> {
         }
         return getItemId(item);
     };
-    renderItem = (item: T, active: boolean) => (
-        <div className={b('item', {active})}>
-            <span className={b('item-text')}>{this.renderItemTitle(item)}</span>
-            <Button
-                view="flat-secondary"
-                size="s"
-                className={b('item-select')}
-                onClick={this.onAddItem.bind(this, item)}
-            >
-                {i18n('button_select')}
-            </Button>
-        </div>
-    );
+    renderItem = (item: T, active: boolean) => {
+        const title = this.renderItemTitle(item);
+        const nativeTitle = typeof title === 'string' ? title : undefined;
+        return (
+            <div className={b('item', {active})}>
+                <span className={b('item-text')} title={nativeTitle}>
+                    {title}
+                </span>
+                <Button
+                    view="flat-secondary"
+                    size="s"
+                    className={b('item-select')}
+                    onClick={this.onAddItem.bind(this, item)}
+                >
+                    {i18n('button_select')}
+                </Button>
+            </div>
+        );
+    };
     filterItem = (filter: string) => (item: T) => {
         const {getItemId} = this.props;
         return getItemId(item).includes(filter);
     };
-    renderValueItem = (item: T, active: boolean) => (
-        <div className={b('value-item', {active})}>
-            <span className={b('value-item-text')}>{this.renderItemTitle(item)}</span>
-            <Button
-                view="flat-secondary"
-                size="s"
-                className={b('value-item-remove')}
-                onClick={() => this.onRemoveItem(item)}
-            >
-                <Icon data={Xmark} size={16} />
-            </Button>
-        </div>
-    );
+    renderValueItem = (item: T, active: boolean) => {
+        const title = this.renderItemTitle(item);
+        const nativeTitle = typeof title === 'string' ? title : undefined;
+        return (
+            <div className={b('value-item', {active})}>
+                <span className={b('value-item-text')} title={nativeTitle}>
+                    {title}
+                </span>
+                <Button
+                    view="flat-secondary"
+                    size="s"
+                    className={b('value-item-remove')}
+                    onClick={() => this.onRemoveItem(item)}
+                >
+                    <Icon data={Xmark} size={16} />
+                </Button>
+            </div>
+        );
+    };
     getActualItems() {
         const {items, value, hideSelected, getItemId} = this.props;
         const actualItems = [];

--- a/src/components/ItemSelector/ItemSelector.tsx
+++ b/src/components/ItemSelector/ItemSelector.tsx
@@ -28,6 +28,7 @@ export interface ItemSelectorProps<T> {
 
     renderItemValue?: (item: T) => React.ReactNode;
     renderItem?: ListProps<T>['renderItem'];
+    renderValueItem?: ListProps<T>['renderItem'];
     filterItem?: ListProps<T>['filterItem'];
 }
 
@@ -130,6 +131,7 @@ export class ItemSelector<T> extends React.Component<ItemSelectorProps<T>> {
             value,
             selectorTitle,
             renderItem = this.renderItem,
+            renderValueItem = this.renderValueItem,
             filterItem = this.filterItem,
             hideSelectAllButton,
         } = this.props;
@@ -174,7 +176,7 @@ export class ItemSelector<T> extends React.Component<ItemSelectorProps<T>> {
                     </div>
                     <List
                         items={selected}
-                        renderItem={this.renderValueItem}
+                        renderItem={renderValueItem}
                         filterItem={filterItem}
                         filterPlaceholder={i18n('placeholder_search')}
                         sortable={true}


### PR DESCRIPTION
There is a problem in
https://github.com/gravity-ui/components/tree/main/src/components/ItemSelector.

Scenario: there is a set of long values with the same beginning but different endings, for example **thisisaverylongcolomnnamenumber1**, **thisisaverylongcolomnnamenumber2**, **thisisaverylongcolomnnamenumber3**.

Currently, due to the CSS properties overflow: hidden; and text-overflow: ellipsis; these values will be cut off on the right and the user will not be able to distinguish them (see screenshots in spoiler blow).

<details>
  <summary>Screenshots</summary>
  
![telegram-cloud-photo-size-2-5195104493652539695-y](https://github.com/user-attachments/assets/a18e1d8a-5d64-43a3-91cc-e62c2e445623)
![telegram-cloud-photo-size-2-5195104493652539696-y](https://github.com/user-attachments/assets/816ff8b3-3b6a-46fc-81c1-c14549831ca3)
![telegram-cloud-photo-size-2-5195160195083400411-y](https://github.com/user-attachments/assets/74b9eaf8-4942-4df4-a8e7-94c3334a8d85)
  
</details>


What has been done:

- At first commit https://github.com/gravity-ui/components/commit/a05cafa92a1b02b7bab036c6c179e975c86cf954 I added a props which is allows to pass custom render function for selected value.
- At second commit https://github.com/gravity-ui/components/commit/6c6245ff26e6be4c84d589446caa3d7066796dd7 I added a title for each item, so user will see the tooltip. I don't sure that is good idea though - the only way to get title text is call `renderItemTitle` which might return not a string, but something else. Maybe we can use here some custom Tooltip component or just drop this commit?
