### PR TITLE
fix(TokenizedInput): handle strict mode double init correctly

### DIFF
--- a/src/components/TokenizedInput/components/Suggestions/hooks/useSuggestions.ts
+++ b/src/components/TokenizedInput/components/Suggestions/hooks/useSuggestions.ts
@@ -61,6 +61,7 @@ export const useSuggestions = <T extends TokenValueBase>({
     );
     const mountedRef = React.useRef(true);
     React.useEffect(() => {
+        mountedRef.current = true;
         return () => {
             mountedRef.current = false;
         };


### PR DESCRIPTION
In strict mode, ref gets inited with true, then the useEffect on (simulated) mount runs, then simulated unmount runs cleanup function and sets it to false, and then during actual mount nothing happens.
So in strict mode, we get `true` -> `false` -> `false`, and during requests, they always get cancelled
For original context, see https://github.com/gravity-ui/components/pull/375/changes#r3000119161