### PR TITLE
fix(Notification): make sources in one vertical line for any themes

### DIFF
--- a/src/components/Notification/Notification.scss
+++ b/src/components/Notification/Notification.scss
@@ -238,6 +238,7 @@ $notificationSideActionsOffset: $notificationSideActionsWidth + 8px;
         background: var(--g-color-base-selection-hover);
     }
 
+    border-inline-start: var(--g-spacing-1) solid transparent;
     &_theme_success {
         border-inline-start: var(--g-spacing-1) solid var(--g-color-line-positive);
     }


### PR DESCRIPTION
Notifications with a theme (success, info, warning, danger) had a colored left border, while default notifications did not. That extra border shifted content horizontally, so source icons and source labels did not line up when notifications with different themes appeared in the same list.

This change adds a transparent border-inline-start to every notification, matching the width of the themed border. All notifications now share the same left inset, so sources stay on one vertical line regardless of theme.