### PR TITLE
fix(ItemSelector): preserve item layout during drag and drop

### DIFF
--- a/src/components/ItemSelector/ItemSelector.scss
+++ b/src/components/ItemSelector/ItemSelector.scss
@@ -53,6 +53,8 @@ $block: '.#{variables.$ns}item-selector';
         overflow: hidden;
         text-overflow: ellipsis;
         margin-inline-end: auto;
+        min-width: 0;
+        flex: 1 1 auto;
     }
 
     &__value-item {
@@ -73,9 +75,14 @@ $block: '.#{variables.$ns}item-selector';
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        min-width: 0;
     }
 
     &__value-item-remove {
         display: none;
     }
+}
+
+#{$block}__list-item {
+    --_--item-padding: var(--g-list-item-padding, 0 16px);
 }

--- a/src/components/ItemSelector/ItemSelector.tsx
+++ b/src/components/ItemSelector/ItemSelector.tsx
@@ -168,6 +168,7 @@ export class ItemSelector<T> extends React.Component<ItemSelectorProps<T>> {
                             </div>
                             <List
                                 items={items}
+                                itemClassName={b('list-item')}
                                 renderItem={renderItem}
                                 filterItem={filterItem}
                                 filterPlaceholder={t('placeholder_search')}
@@ -190,6 +191,7 @@ export class ItemSelector<T> extends React.Component<ItemSelectorProps<T>> {
                             </div>
                             <List
                                 items={selected}
+                                itemClassName={b('list-item')}
                                 renderItem={renderValueItem}
                                 filterItem={filterItem}
                                 filterPlaceholder={t('placeholder_search')}


### PR DESCRIPTION
### Summary of Changes
- Pass `itemClassName={b('list-item')}` to both `List` components in `ItemSelector` so items retain their container padding (`0 16px`) when cloned/dragged outside the container.
- Add `min-width: 0` and `flex: 1 1 auto` to `&__item-text` and `&__value-item-text` in `ItemSelector.scss` to properly support custom `renderItemValue` layouts (e.g. flex containers) and prevent layout distortion during drag and hover state transitions.

Closes #400
